### PR TITLE
対話インテントのテスト

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,43 @@ const AddUserIntentHandler = {
     },
 };
 
+const DialogIntentHandler = {
+    canHandle(handlerInput) {
+        return handlerInput.requestEnvelope.request.type === 'IntentRequest'
+            && handlerInput.requestEnvelope.request.intent.name === 'DialogIntent';
+    },
+    handle(handlerInput) {
+        const speechText = `こんにちは。挨拶を返してください。`;
+
+        return handlerInput.responseBuilder
+            .speak(speechText)
+            .reprompt()
+            .getResponse();
+    },
+};
+
+const DialogHelloIntentHandler = {
+    canHandle(handlerInput) {
+        return handlerInput.requestEnvelope.request.type === 'IntentRequest'
+            && handlerInput.requestEnvelope.request.intent.name === 'DialogHelloIntent';
+    },
+    async handle(handlerInput) {
+        const speechText = `挨拶を返してくれてありがとう。挨拶スタンプをデータベースに登録します。`;
+        const params = {
+            TableName: 'userList',
+            Item: {
+                name: `特殊`,
+                stamp: `スタンプ`
+            }
+        };
+        await dynamoDB.put(params).promise();
+
+        return handlerInput.responseBuilder
+            .speak(speechText)
+            .getResponse();
+    },
+};
+
 const GetAllUserIntentHandler = {
     canHandle(handlerInput) {
         return handlerInput.requestEnvelope.request.type === 'IntentRequest'
@@ -91,7 +128,7 @@ const CancelAndStopIntentHandler = {
                 || handlerInput.requestEnvelope.request.intent.name === 'AMAZON.StopIntent');
     },
     handle(handlerInput) {
-        const speechText = 'さようなら';
+        const speechText = '終了します';
 
         return handlerInput.responseBuilder
             .speak(speechText)
@@ -130,6 +167,8 @@ exports.handler = skillBuilder
         LaunchRequestHandler,
         HelloWorldIntentHandler,
         AddUserIntentHandler,
+        DialogIntentHandler,
+        DialogHelloIntentHandler,
         GetAllUserIntentHandler,
         CancelAndStopIntentHandler,
         SessionEndedRequestHandler


### PR DESCRIPTION
## このプルリクエストの概要
ユーザー一括の初期登録を実装するための対話インテントのテスト実装
HelloWolrdをベースに、ユーザーとの対話とDB登録を行う

## チケットへのリンク
* https://github.com/YuyaOsaka/echoSystem/projects/1#card-48371703

## 具体的な作業一覧（変更理由も含めて）
* DialogIntentHandlerとDialogHelloIntentHandlerの追加
* インテント2つで対話を実現（.reprompt()の機能）
　名前の初期登録の実装時はDialogHelloIntentを繰り返すことで実装予定
* DB接続テストとしてあいさつスタンプの登録を追加

* [x] 上記全ての機能が入った最終版をテストしましたか？
　（Alexa Developer Consoleでテスト済み　画像は最下部を参照してください）

## 特に見て欲しいところ
変更点の中で、特に確認が必要なものになります。

* 対話機能の実装方法の確認
* 発話内容とテスト画面の結果の一致

![対話テスト](https://user-images.githubusercontent.com/69957360/98072103-98184b00-1ea8-11eb-9af9-d3296fbed5ab.png)
![対話テストDB](https://user-images.githubusercontent.com/69957360/98072111-9babd200-1ea8-11eb-84d9-64507c59c739.png)
