### PR TITLE
ユーザーの初期登録機能の実装

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,7 @@ const DialogIntentHandler = {
             && handlerInput.requestEnvelope.request.intent.name === 'DialogIntent';
     },
     handle(handlerInput) {
-        const speechText = `誰を追加しますか？まるまるさんを追加、のように教えてください。
-                            追加を終了する場合は、追加を終了と発話してください。`;
+        const speechText = `こんにちは。挨拶を返してください。`;
 
         return handlerInput.responseBuilder
             .speak(speechText)
@@ -73,27 +72,24 @@ const DialogIntentHandler = {
     },
 };
 
-const DialogAddIntentHandler = {
+const DialogHelloIntentHandler = {
     canHandle(handlerInput) {
         return handlerInput.requestEnvelope.request.type === 'IntentRequest'
-            && handlerInput.requestEnvelope.request.intent.name === 'DialogAddIntent';
+            && handlerInput.requestEnvelope.request.intent.name === 'DialogHelloIntent';
     },
     async handle(handlerInput) {
-        // スロットからユーザー名を取得
-        const inputName = handlerInput.requestEnvelope.request.intent.slots.name.value;
-        // DynamoDBにユーザーを追加
+        const speechText = `挨拶を返してくれてありがとう。挨拶スタンプをデータベースに登録します。`;
         const params = {
             TableName: 'userList',
             Item: {
-                name: inputName
+                name: `特殊`,
+                stamp: `スタンプ`
             }
         };
         await dynamoDB.put(params).promise();
-        const speechText = `${inputName}さんを当番表に追加しました。`;
 
         return handlerInput.responseBuilder
             .speak(speechText)
-            .reprompt()
             .getResponse();
     },
 };
@@ -172,7 +168,7 @@ exports.handler = skillBuilder
         HelloWorldIntentHandler,
         AddUserIntentHandler,
         DialogIntentHandler,
-        DialogAddIntentHandler,
+        DialogHelloIntentHandler,
         GetAllUserIntentHandler,
         CancelAndStopIntentHandler,
         SessionEndedRequestHandler

--- a/index.js
+++ b/index.js
@@ -11,15 +11,15 @@ const LaunchRequestHandler = {
             && handlerInput.requestEnvelope.request.intent.name === 'AMAZON.HelpIntent');
     },
     handle(handlerInput) {
-        const launchRequestText = `このスキルではスピーチ当番の確認ができます。
+        const speechOutput = `このスキルではスピーチ当番の確認ができます。
                                     他にもユーザーの初期登録、ユーザーの追加、
                                     ユーザーの削除、登録されているユーザーの確認、
                                     当番のスキップが行えます。`;
-        const launchRequestRepromptText = `行う操作を教えてください。`;
+        const repromptSpeechOutput = `行う操作を教えてください。`;
 
         return handlerInput.responseBuilder
-            .speak(launchRequestText)
-            .reprompt(launchRequestRepromptText)
+            .speak(speechOutput)
+            .reprompt(repromptSpeechOutput)
             .getResponse();
     },
 };
@@ -40,10 +40,10 @@ const AddUserIntentHandler = {
             }
         };
         await dynamoDB.put(params).promise();
-        const addUserText = `${inputName}さんを当番表に追加しました。`;
+        const speechOutput = `${inputName}さんを当番表に追加しました。`;
 
         return handlerInput.responseBuilder
-            .speak(addUserText)
+            .speak(speechOutput)
             .getResponse();
     },
 };
@@ -54,13 +54,13 @@ const DialogIntentHandler = {
             && handlerInput.requestEnvelope.request.intent.name === 'DialogIntent';
     },
     handle(handlerInput) {
-        const dialogText = `誰を追加しますか？まるまるさんを追加、のように教えてください。
+        const speechOutput = `誰を追加しますか？まるまるさんを追加、のように教えてください。
                             追加を終了する場合は、追加を終了と発話してください。`;
-        const dialogRepromptText = `行う操作を教えてください。`;
+        const repromptSpeechOutput = `行う操作を教えてください。`;
 
         return handlerInput.responseBuilder
-            .speak(dialogText)
-            .reprompt(dialogRepromptText)
+            .speak(speechOutput)
+            .reprompt(repromptSpeechOutput)
             .getResponse();
     },
 };
@@ -81,12 +81,12 @@ const DialogAddIntentHandler = {
             }
         };
         await dynamoDB.put(params).promise();
-        const dialogAddText = `${inputName}さんを当番表に追加しました。`;
-        const dialogAddRepromptText = `終了しますか？終了する場合は、追加を終了と発話してください。`;
+        const speechOutput = `${inputName}さんを当番表に追加しました。`;
+        const repromptSpeechOutput = `終了しますか？終了する場合は、追加を終了と発話してください。`;
 
         return handlerInput.responseBuilder
-            .speak(dialogAddText)
-            .reprompt(dialogAddRepromptText)
+            .speak(speechOutput)
+            .reprompt(repromptSpeechOutput)
             .getResponse();
     },
 };
@@ -97,10 +97,10 @@ const DialogEndIntentHandler = {
             && handlerInput.requestEnvelope.request.intent.name === 'DialogEndIntent';
     },
     handle(handlerInput) {
-        const dialogEndText = `ユーザーの登録を終了します。`;
+        const speechOutput = `ユーザーの登録を終了します。`;
 
         return handlerInput.responseBuilder
-            .speak(dialogEndText)
+            .speak(speechOutput)
             .getResponse();
     },
 };
@@ -120,14 +120,14 @@ const GetAllUserIntentHandler = {
         allUserList.push(...result.Items);
 
         // 取得した名前データをテキストに追加
-        let getAllUserText = `当番表に登録されているメンバーは、`;
+        let speechOutput = `当番表に登録されているメンバーは、`;
         for (const i in allUserList) {
-            getAllUserText += `${allUserList[i].name}さん、`;
+            speechOutput += `${allUserList[i].name}さん、`;
         }
-        getAllUserText += `です。`;
+        speechOutput += `です。`;
 
         return handlerInput.responseBuilder
-            .speak(getAllUserText)
+            .speak(speechOutput)
             .getResponse();
     },
 };

--- a/index.js
+++ b/index.js
@@ -11,24 +11,15 @@ const LaunchRequestHandler = {
             && handlerInput.requestEnvelope.request.intent.name === 'AMAZON.HelpIntent');
     },
     handle(handlerInput) {
-        const speechText = 'Hello World.';
+        const launchRequestText = `このスキルではスピーチ当番の確認ができます。
+                                    他にもユーザーの初期登録、ユーザーの追加、
+                                    ユーザーの削除、登録されているユーザーの確認、
+                                    当番のスキップが行えます。`;
+        const launchRequestRepromptText = `行う操作を教えてください。`;
 
         return handlerInput.responseBuilder
-            .speak(speechText)
-            .getResponse();
-    },
-};
-
-const HelloWorldIntentHandler = {
-    canHandle(handlerInput) {
-        return handlerInput.requestEnvelope.request.type === 'IntentRequest'
-            && handlerInput.requestEnvelope.request.intent.name === 'HelloWorldIntent';
-    },
-    handle(handlerInput) {
-        const speechText = 'Hello World Good Day.';
-
-        return handlerInput.responseBuilder
-            .speak(speechText)
+            .speak(launchRequestText)
+            .reprompt(launchRequestRepromptText)
             .getResponse();
     },
 };
@@ -49,10 +40,10 @@ const AddUserIntentHandler = {
             }
         };
         await dynamoDB.put(params).promise();
-        const speechText = `${inputName}さんを当番表に追加しました。`;
+        const addUserText = `${inputName}さんを当番表に追加しました。`;
 
         return handlerInput.responseBuilder
-            .speak(speechText)
+            .speak(addUserText)
             .getResponse();
     },
 };
@@ -63,12 +54,13 @@ const DialogIntentHandler = {
             && handlerInput.requestEnvelope.request.intent.name === 'DialogIntent';
     },
     handle(handlerInput) {
-        const speechText = `誰を追加しますか？まるまるさんを追加、のように教えてください。
+        const dialogText = `誰を追加しますか？まるまるさんを追加、のように教えてください。
                             追加を終了する場合は、追加を終了と発話してください。`;
+        const dialogRepromptText = `行う操作を教えてください。`;
 
         return handlerInput.responseBuilder
-            .speak(speechText)
-            .reprompt()
+            .speak(dialogText)
+            .reprompt(dialogRepromptText)
             .getResponse();
     },
 };
@@ -89,11 +81,26 @@ const DialogAddIntentHandler = {
             }
         };
         await dynamoDB.put(params).promise();
-        const speechText = `${inputName}さんを当番表に追加しました。`;
+        const dialogAddText = `${inputName}さんを当番表に追加しました。`;
+        const dialogAddRepromptText = `終了しますか？終了する場合は、追加を終了と発話してください。`;
 
         return handlerInput.responseBuilder
-            .speak(speechText)
-            .reprompt()
+            .speak(dialogAddText)
+            .reprompt(dialogAddRepromptText)
+            .getResponse();
+    },
+};
+
+const DialogEndIntentHandler = {
+    canHandle(handlerInput) {
+        return handlerInput.requestEnvelope.request.type === 'IntentRequest'
+            && handlerInput.requestEnvelope.request.intent.name === 'DialogEndIntent';
+    },
+    handle(handlerInput) {
+        const dialogEndText = `ユーザーの登録を終了します。`;
+
+        return handlerInput.responseBuilder
+            .speak(dialogEndText)
             .getResponse();
     },
 };
@@ -113,14 +120,14 @@ const GetAllUserIntentHandler = {
         allUserList.push(...result.Items);
 
         // 取得した名前データをテキストに追加
-        let speechText = '当番表に登録されているメンバーは、';
+        let getAllUserText = `当番表に登録されているメンバーは、`;
         for (const i in allUserList) {
-            speechText += `${allUserList[i].name}さん、`;
+            getAllUserText += `${allUserList[i].name}さん、`;
         }
-        speechText += 'です。';
+        getAllUserText += `です。`;
 
         return handlerInput.responseBuilder
-            .speak(speechText)
+            .speak(getAllUserText)
             .getResponse();
     },
 };
@@ -132,10 +139,8 @@ const CancelAndStopIntentHandler = {
                 || handlerInput.requestEnvelope.request.intent.name === 'AMAZON.StopIntent');
     },
     handle(handlerInput) {
-        const speechText = '終了します';
-
         return handlerInput.responseBuilder
-            .speak(speechText)
+            .speak(`終了します`)
             .getResponse();
     },
 };
@@ -159,7 +164,7 @@ const ErrorHandler = {
         console.log(`Error handled: ${error.message}`);
 
         return handlerInput.responseBuilder
-            .speak('エラーが発生しました')
+            .speak(`エラーが発生しました`)
             .getResponse();
     },
 };
@@ -169,10 +174,10 @@ const skillBuilder = Alexa.SkillBuilders.custom();
 exports.handler = skillBuilder
     .addRequestHandlers(
         LaunchRequestHandler,
-        HelloWorldIntentHandler,
         AddUserIntentHandler,
         DialogIntentHandler,
         DialogAddIntentHandler,
+        DialogEndIntentHandler,
         GetAllUserIntentHandler,
         CancelAndStopIntentHandler,
         SessionEndedRequestHandler

--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ const DialogIntentHandler = {
             && handlerInput.requestEnvelope.request.intent.name === 'DialogIntent';
     },
     handle(handlerInput) {
-        const speechText = `こんにちは。挨拶を返してください。`;
+        const speechText = `誰を追加しますか？まるまるさんを追加、のように教えてください。
+                            追加を終了する場合は、追加を終了と発話してください。`;
 
         return handlerInput.responseBuilder
             .speak(speechText)
@@ -72,24 +73,27 @@ const DialogIntentHandler = {
     },
 };
 
-const DialogHelloIntentHandler = {
+const DialogAddIntentHandler = {
     canHandle(handlerInput) {
         return handlerInput.requestEnvelope.request.type === 'IntentRequest'
-            && handlerInput.requestEnvelope.request.intent.name === 'DialogHelloIntent';
+            && handlerInput.requestEnvelope.request.intent.name === 'DialogAddIntent';
     },
     async handle(handlerInput) {
-        const speechText = `挨拶を返してくれてありがとう。挨拶スタンプをデータベースに登録します。`;
+        // スロットからユーザー名を取得
+        const inputName = handlerInput.requestEnvelope.request.intent.slots.name.value;
+        // DynamoDBにユーザーを追加
         const params = {
             TableName: 'userList',
             Item: {
-                name: `特殊`,
-                stamp: `スタンプ`
+                name: inputName
             }
         };
         await dynamoDB.put(params).promise();
+        const speechText = `${inputName}さんを当番表に追加しました。`;
 
         return handlerInput.responseBuilder
             .speak(speechText)
+            .reprompt()
             .getResponse();
     },
 };
@@ -168,7 +172,7 @@ exports.handler = skillBuilder
         HelloWorldIntentHandler,
         AddUserIntentHandler,
         DialogIntentHandler,
-        DialogHelloIntentHandler,
+        DialogAddIntentHandler,
         GetAllUserIntentHandler,
         CancelAndStopIntentHandler,
         SessionEndedRequestHandler


### PR DESCRIPTION
## このプルリクエストの概要
HelloWolrdで対話するインテントを元に、ユーザーの初期登録（一括登録）インテントを実装

## チケットへのリンク
* https://github.com/YuyaOsaka/echoSystem/projects/1#card-46874199

## 具体的な作業一覧（変更理由も含めて）
* アレクサ側の発話内容の変更
* DialogAddIntentが複数回呼ばれるように修正
　.reprompt()を追加
* 終了時にDB内部を発話するように変更
　GetAllUserIntentの発話サンプルに「追加を終了」を追加

* [x] 上記全ての機能が入った最終版をテストしましたか？

## 特に見て欲しいところ
変更点の中で、特に確認が必要なものになります。

* インテントの呼び出しが正しく行われているか（特にDialogAddIntent）
* 呼び出し内容と結果で整合性が取れているか
* .reprompt()が含まれないインテントを呼び出した後の動作（SS(3)を参照）

## スクリーンショット一覧
コンソールテスト画面スクリーンショット（1）
![対話実装1](https://user-images.githubusercontent.com/69957360/98076185-209ae980-1eb1-11eb-9793-2f5040e0b2a4.png)

コンソールテスト画面スクリーンショット（2）
![対話実装2](https://user-images.githubusercontent.com/69957360/98076201-2a245180-1eb1-11eb-8b6c-f7474deb20ec.png)

コンソールテスト画面スクリーンショット（3）
![対話実装3](https://user-images.githubusercontent.com/69957360/98076212-33152300-1eb1-11eb-8910-31375c00977f.png)

実行後のDB内部データスクリーンショット
![対話実装DB](https://user-images.githubusercontent.com/69957360/98076241-432d0280-1eb1-11eb-8ebd-ef87f6dbec32.png)