### PR TITLE
Feature/add yesno model

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,9 @@ const DialogFirstAddIntentHandler = {
         attributesManager.setPersistentAttributes({'userList':allUserList});
         await attributesManager.savePersistentAttributes();
 
-        const speechOutput = `${inputName}さんを当番表に追加しました。`;
-        const repromptSpeechOutput = '終了しますか？終了する場合は、追加を終了と発話してください。';
-
+        const speechOutput = `${inputName}さんを当番表に初期登録します。既にユーザーデータがある場合は上書きされます。よろしいですか？`;
+        const repromptSpeechOutput = '初期登録の確認をします。「はい」か「いいえ」で応答してください';
+        
         return handlerInput.responseBuilder
             .speak(speechOutput)
             .reprompt(repromptSpeechOutput)


### PR DESCRIPTION
## このプルリクエストの概要
初期登録インテントが既存のデータを上書きして最初の一人を登録するため、登録時にはい/いいえの確認を行う機能を追加しました。
今回の機能面の修正は主にAlexa Developer Console上で行われたため、添付スクリーンショットにてご確認ください。

## チケットへのリンク
* https://github.com/YuyaOsaka/echoSystem/projects/1#card-49264626

## 具体的な作業一覧（変更理由も含めて）
* 初期登録インテントに使用されるスロット（{name}で名前をalexaに伝える機能）に対話機能を設定
![yesno_console_1](https://user-images.githubusercontent.com/69957360/99469648-8e054a80-2986-11eb-99fe-b88714b69fe3.png)
* index.jsファイルの文言の修正

* [x] 上記全ての機能が入った最終版をテストしましたか？

## 特に見て欲しいところ
変更点の中で、特に確認が必要なものになります。

* **初期登録→はいの場合**
![yesno_1](https://user-images.githubusercontent.com/69957360/99469723-b3925400-2986-11eb-84b3-dde40d4b3c65.png)

　DB結果
![yesno_db_1](https://user-images.githubusercontent.com/69957360/99469743-bf7e1600-2986-11eb-9597-3596b1704023.png)


* **初期登録→いいえの場合（DB未登録の状態から開始）**
![yesno_2](https://user-images.githubusercontent.com/69957360/99469758-ca38ab00-2986-11eb-859b-86ca0e0e9346.png)

　DB結果
![yesno_db_2](https://user-images.githubusercontent.com/69957360/99469790-d7ee3080-2986-11eb-903a-feedc0874a68.png)


* **追加登録で確認が発生しないことの確認**
![yesno_3](https://user-images.githubusercontent.com/69957360/99470146-927e3300-2987-11eb-9985-f82fc7251db1.png)

　DB結果
![yesno_db_3](https://user-images.githubusercontent.com/69957360/99470162-9a3dd780-2987-11eb-9823-6984614c5232.png)