### PR TITLE
Feature/add duty intent

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,13 +170,13 @@ const GetDutyIntentHandler = {
         const currentDate = dayjs(new Date(currentDateTime.getFullYear(), currentDateTime.getMonth(), 
             currentDateTime.getDate())).format('YYYY/MM/DD');
         // 初期登録日を形式変換
-        const addDate = dayjs(currentData.registrationDate).format('YYYY/MM/DD');
+        const firstAddDate = dayjs(currentData.registrationDate).format('YYYY/MM/DD');
         
         // 現在日と初期登録日の差分算出し、当番を決定
-        const dutyNumber = dayjs(currentDate).diff(addDate, 'days') % currentData.userList.length;
+        const index = dayjs(currentDate).diff(firstAddDate, 'days') % currentData.userList.length;
 
         // 当番の名前データをテキストに追加
-        const speechOutput = `今日のスピーチ当番は、${currentData.userList[dutyNumber]}さんです。`;
+        const speechOutput = `今日のスピーチ当番は、${currentData.userList[index]}さんです。`;
 
         return handlerInput.responseBuilder
             .speak(speechOutput)
@@ -193,8 +193,7 @@ const GetAllUserIntentHandler = {
         // テーブル内のデータを取得
         const attributesManager = handlerInput.attributesManager;
         const attributes = await attributesManager.getPersistentAttributes() || {};
-        const currentData = JSON.parse(attributes.data);
-        const allUserList = currentData.userList;
+        const allUserList = JSON.parse(attributes.data).userList;
 
         // 取得した名前データをテキストに追加
         let speechOutput = '当番表に登録されているメンバーは、';

--- a/package-lock.json
+++ b/package-lock.json
@@ -359,6 +359,11 @@
         "which": "^2.0.1"
       }
     },
+    "dayjs": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.6.tgz",
+      "integrity": "sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw=="
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "ask-sdk-core": "^2.10.1",
-    "ask-sdk-model": "^1.33.1"
+    "ask-sdk-model": "^1.33.1",
+    "dayjs": "^1.9.6"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
## このプルリクエストの概要
日付からスピーチ当番を決定するインテントの実装になります。
日時のparseと差分の計算を行うためにdayjsを導入しました。

## チケットへのリンク
* https://github.com/YuyaOsaka/echoSystem/projects/1#card-49111764

## 具体的な作業一覧（変更理由も含めて）
* 初期登録インテントで登録日をDBに登録するように変更

*上記変更に伴い、各インテントでのDBからの読み取り/書き込み部分の修正 
* 日付を利用してスピーチ当番を決定する機能を実装
dayjsを利用して、(登録日と現在日の差分日数) % (DBに登録されているユーザー数)で当番を決定

* [x] 上記全ての機能が入った最終版をテストしましたか？

## 3種類のテスト結果
* **2020/11/19登録　2020/11/19呼び出し**
結果
![day_5](https://user-images.githubusercontent.com/69957360/99633363-1caac200-2a82-11eb-885e-470264ad6efb.png)

DB
![day_db](https://user-images.githubusercontent.com/69957360/99633380-22a0a300-2a82-11eb-8119-f76aa1a15d07.png)

* **2019/02/09登録　2020/11/19呼び出し**
結果（確認のため、各日にちと登録人数を表示しています。山田、斎藤が登録されている状態です）
![day_4](https://user-images.githubusercontent.com/69957360/99633441-4368f880-2a82-11eb-94f6-80c9e7c26a9a.png)
![day_3](https://user-images.githubusercontent.com/69957360/99633529-67c4d500-2a82-11eb-98aa-6d8e13f27757.png)
※登録日は数値を別途代入することで決定し確認を行いました。

* **2019/02/10登録　2020/11/19呼び出し**
結果
![day_2](https://user-images.githubusercontent.com/69957360/99633562-73180080-2a82-11eb-838e-5859dee24ffc.png)
![day_1](https://user-images.githubusercontent.com/69957360/99633573-76ab8780-2a82-11eb-9b37-4737033c19a7.png)

## 特に見て欲しいところ
変更点の中で、特に確認が必要なものになります。

* 当番決定のプロセスに問題点がないか
* 各テストの結果に不備がないか
