### PR TITLE
ユーザーを削除するインテントの実装

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,8 +270,8 @@ const DeleteIntentHandler = {
         let speechOutput;
         for (const i in allUserList.userList) {
             if(allUserList.userList[i] === inputName) {
-                if(allUserList.userList.length === 1) {
-                    speechOutput = 'リストが1名の場合は、削除を行えません。'
+                if(allUserList.userList.length <= 1) {
+                    speechOutput = 'リストが1名以下の場合は、削除を行えません。'
                     break;
                 }
                 speechOutput = `削除が完了しました。

--- a/index.js
+++ b/index.js
@@ -267,25 +267,26 @@ const DeleteIntentHandler = {
         const allUserList = JSON.parse(attributes.data);
 
         // 取得した名前データをテキストに追加
-        let speechOutput;
+        if(allUserList.userList.length <= 1) {
+            return handlerInput.responseBuilder
+                .speak('リストが1名以下の場合は、削除を行えません。')
+                .getResponse();
+        }
         for (const i in allUserList.userList) {
             if(allUserList.userList[i] === inputName) {
-                if(allUserList.userList.length <= 1) {
-                    speechOutput = 'リストが1名以下の場合は、削除を行えません。'
-                    break;
-                }
-                speechOutput = `削除が完了しました。
-                                削除されたメンバーは、${allUserList.userList[i]}さんです。`;
+                const speechOutput = `削除が完了しました。削除されたメンバーは、
+                                        ${allUserList.userList[i]}さんです。`
                 allUserList.userList.splice(i, 1);
                 attributesManager.setPersistentAttributes({'data':JSON.stringify(allUserList)});
                 await attributesManager.savePersistentAttributes()
-                break;
+                return handlerInput.responseBuilder
+                    .speak(speechOutput)
+                    .getResponse();
             }
-            speechOutput = `${inputName}さんは見つかりませんでした。`;
         }
 
         return handlerInput.responseBuilder
-            .speak(speechOutput)
+            .speak(`${inputName}さんは見つかりませんでした。`)
             .getResponse();
     },
 };


### PR DESCRIPTION
## このプルリクエストの概要
ユーザーを削除するインテント（Delete Intent）の実装を行いました。

## チケットへのリンク
* https://github.com/YuyaOsaka/echoSystem/projects/1#card-46874257

## 具体的な作業一覧（変更理由も含めて）
* Delete Intent Handlerの作成
* DBのuserListが残り一名以下の場合、削除が行えないように設定

* [x] 上記全ての機能が入った最終版をテストしましたか？

## テストSS
* **削除処理の動作**
・DB初期状態
![DB_First](https://user-images.githubusercontent.com/69957360/100319985-e3370100-3003-11eb-88fa-c283f4433738.png)
・削除実行①（斉藤を当番表から削除）
![Test_1](https://user-images.githubusercontent.com/69957360/100320033-f77afe00-3003-11eb-8448-bbafd8813ea9.png)
・削除実行②（中山も削除後、当番表に山田のみの状態で削除処理を実行）
![Test_2](https://user-images.githubusercontent.com/69957360/100320197-314c0480-3004-11eb-9286-d9b0db60e445.png)
・最終的なDB状態
![DB_End](https://user-images.githubusercontent.com/69957360/100320218-3b6e0300-3004-11eb-8b21-d3aeebd4595a.png)
・当番表に存在しない人を削除しようとした場合
![Test_3](https://user-images.githubusercontent.com/69957360/100320512-9a337c80-3004-11eb-89ed-514edff38883.png)

## 特に見て欲しいところ
変更点の中で、特に確認が必要なものになります。

* 削除対象者決定の手順
for文内部以外はほぼ変更点がないので、内部を重点的に確認していただきたいです。