### PR TITLE
当番決定方法の修正

### DIFF
--- a/bin/upload.sh
+++ b/bin/upload.sh
@@ -3,5 +3,5 @@
 zip -r nodejs.zip ./
 
 aws lambda update-function-code \
-    --function-name HelloWorldTestSkill \
+    --function-name SpeechOnDuty \
     --zip-file fileb://nodejs.zip


### PR DESCRIPTION
## このプルリクエストの概要
ソート機能実装にあたってDBに当番となっている人の名前を保持することとなり、それに伴って既存の当番決定方法に修正が入りました。

## チケットへのリンク
* https://github.com/YuyaOsaka/echoSystem/projects/1#card-49730106

## 具体的な作業一覧（変更理由も含めて）
* 初期登録時、登録者を当番者として保持するよう変更
* GetDutyIntent, SkipIntentにおいて、当番決定方法をDBの当番者情報を参照して決定する方式に変更
* DeleteIntent動作時、削除対象者が当番だった場合にリストの次の人が当番者に選ばれる機能を追加

* [x] 上記全ての機能が入った最終版をテストしましたか？

## 特に見て欲しいところ
変更点の中で、特に確認が必要なものになります。

* 上記3種Intentの当番決定プロセス