### PR TITLE
alexaがメールアドレスをユーザー情報として取得するよう変更

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ const DialogFirstAddIntentHandler = {
             return responseBuilder
                 .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')
                 .withAskForPermissionsConsentCard(PERMISSIONS)
-              .getResponse();
+                .getResponse();
         }
     },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ const DialogFirstAddIntentHandler = {
               console.log(`ERROR StatusCode:${  error.statusCode  } ${  error.message}`);
             }
             return responseBuilder
-              .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')
+                .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')
               .withAskForPermissionsConsentCard(PERMISSIONS)
               .getResponse();
         }

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ const DialogFirstAddIntentHandler = {
             }
             return responseBuilder
                 .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')
-              .withAskForPermissionsConsentCard(PERMISSIONS)
+                .withAskForPermissionsConsentCard(PERMISSIONS)
               .getResponse();
         }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ const DialogFirstAddIntentHandler = {
                 .getResponse();
         } catch (error) {
             if (error.name == 'ServiceError') {
-                console.log(`ERROR StatusCode:${error.statusCode  } ${  error.message}`);
+                console.log(`ERROR StatusCode:${error.statusCode} ${  error.message}`);
             }
             return responseBuilder
                 .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ const DialogFirstAddIntentHandler = {
         // 登録日を取得
         const firstAddDate = day.getFormartedDate();
 
-        // ユーザー情報の取得可否確認
+        // メールアドレス情報の取得可否確認用
         const { responseBuilder, serviceClientFactory } = handlerInput;
 
         try {

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ const DialogFirstAddIntentHandler = {
                 .getResponse();
         } catch (error) {
             if (error.name == 'ServiceError') {
-              console.log(`ERROR StatusCode:${  error.statusCode  } ${  error.message}`);
+                console.log(`ERROR StatusCode:${  error.statusCode  } ${  error.message}`);
             }
             return responseBuilder
                 .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ const DialogFirstAddIntentHandler = {
                 .getResponse();
         } catch (error) {
             if (error.name == 'ServiceError') {
-              console.log('ERROR StatusCode:' + error.statusCode + ' ' + error.message);
+              console.log(`ERROR StatusCode:${  error.statusCode  } ${  error.message}`);
             }
             return responseBuilder
               .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ const DialogFirstAddIntentHandler = {
                 .getResponse();
         } catch (error) {
             if (error.name == 'ServiceError') {
-                console.log(`ERROR StatusCode:${error.statusCode} ${  error.message}`);
+                console.log(`ERROR StatusCode:${error.statusCode} ${error.message}`);
             }
             return responseBuilder
                 .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ const config = {tableName: 'userTable',
     attributesName: 'userAndDate'};
 const dynamoDBAdapter = new adapter.DynamoDbPersistenceAdapter(config);
 
+const PERMISSIONS = ['alexa::profile:email:read'];
+
 const LaunchRequestHandler = {
     canHandle(handlerInput) {
         return handlerInput.requestEnvelope.request.type === 'LaunchRequest'
@@ -76,21 +78,36 @@ const DialogFirstAddIntentHandler = {
         // 登録日を取得
         const firstAddDate = day.getFormartedDate();
 
-        // スロットからユーザー名を取得
-        const inputName = handlerInput.requestEnvelope.request.intent.slots.name.value;
-        const inputNameReading = await yomigana.getYomigana(inputName);
+        // ユーザー情報の取得可否確認
+        const { responseBuilder, serviceClientFactory } = handlerInput;
 
-        // DynamoDBにユーザーと登録日を追加
-        const allUserList = {userList:[{name:inputName, read:inputNameReading}], calledDate:firstAddDate, dutyName:inputName};
-        await dynamoDB.putUserData(handlerInput, allUserList);
+        try {
+            // メールアドレス情報の取得
+            const deviceAddressServiceClient = serviceClientFactory.getUpsServiceClient();
+            const email = await deviceAddressServiceClient.getProfileEmail(); 
 
-        const speechOutput = `${inputName}さんを当番表に初期登録しました。`;
-        const repromptSpeechOutput = '初期登録の確認をします。「はい」か「いいえ」で応答してください';
+            // スロットからユーザー名を取得
+            const inputName = handlerInput.requestEnvelope.request.intent.slots.name.value;
+            const inputNameReading = await yomigana.getYomigana(inputName);
 
-        return handlerInput.responseBuilder
-            .speak(speechOutput)
-            .reprompt(repromptSpeechOutput)
-            .getResponse();
+            // DynamoDBにユーザーと登録日を追加
+            const allUserList = {userList:[{name:inputName, read:inputNameReading}], calledDate:firstAddDate, dutyName:inputName, mailAddress:email};
+            await dynamoDB.putUserData(handlerInput, allUserList);
+
+            const speechOutput = `${inputName}さんを当番表に初期登録しました。`;
+            
+            return handlerInput.responseBuilder
+                .speak(speechOutput)
+                .getResponse();
+        } catch (error) {
+            if (error.name == 'ServiceError') {
+              console.log('ERROR StatusCode:' + error.statusCode + ' ' + error.message);
+            }
+            return responseBuilder
+              .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')
+              .withAskForPermissionsConsentCard(PERMISSIONS)
+              .getResponse();
+        }
     },
 };
 
@@ -156,7 +173,8 @@ const GetDutyIntentHandler = {
 
             updateData = {userList:currentData.userList, 
                 calledDate:currentData.calledDate,
-                dutyName:newDuty};
+                dutyName:newDuty,
+                mailAddress:currentData.mailAddress};
             dynamoDB.putUserData(handlerInput, updateData);
             currentData = await dynamoDB.getUserData(handlerInput);
         }
@@ -187,7 +205,8 @@ const SkipIntentHandler = {
         }
         const updateData = {userList:currentData.userList, 
             calledDate:currentData.calledDate,
-            dutyName:newDuty};
+            dutyName:newDuty,
+            mailAddress:currentData.mailAddress};
         dynamoDB.putUserData(handlerInput, updateData);
 
         // 新しい当番の名前データをテキストに追加
@@ -277,7 +296,8 @@ const SortIntentHandler = {
 
         const updateData = {userList:sortedList, 
             calledDate:currentData.calledDate,
-            dutyName:currentData.dutyName};
+            dutyName:currentData.dutyName,
+            mailAddress:currentData.mailAddress};
         dynamoDB.putUserData(handlerInput, updateData);
 
         // データを再取得

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ const DialogFirstAddIntentHandler = {
                 .getResponse();
         } catch (error) {
             if (error.name == 'ServiceError') {
-                console.log(`ERROR StatusCode:${  error.statusCode  } ${  error.message}`);
+                console.log(`ERROR StatusCode:${error.statusCode  } ${  error.message}`);
             }
             return responseBuilder
                 .speak('メールアドレスの利用が許可されていません。アレクサアプリの設定を変更して下さい。')


### PR DESCRIPTION
## このプルリクエストの概要
webアプリ側でメールアドレス判別を行うために、alexaがメールアドレス取得し保持するよう変更を加えました。

## チケットへのリンク
* https://github.com/YuyaOsaka/alexa-management-system/projects/1#card-53072468

## 具体的な作業一覧（変更理由も含めて）
* developer consoleでメールアドレスを取得する設定に変更
![setting](https://user-images.githubusercontent.com/69957360/106422571-2dc07800-64a2-11eb-80f3-06b6e23c89c6.png)

* index.js 初期登録インテントにメールアドレス取得用コードを追加
* スキル有効時、ユーザーがメールアドレス取得を許可していない場合に例外が発生し、エラーメッセージが読まれるように変更
* メールアドレス取得とは直接関係のない軽微な変更ですが、初期登録インテントでユーザー登録後に待機状態となる設定を登録後インテントを終了する設定へと変更しました。

* [x] 上記全ての機能が入った最終版をテストしましたか？
今回の変更に伴い、メールアドレスの取得許可を設定できないと思われるdeveloper console上のテストは行えなくなりました。
実機テストは項目追加によって影響が発生したインテントを含め問題なく動作しました。
![test](https://user-images.githubusercontent.com/69957360/106422816-9dcefe00-64a2-11eb-8c30-106c619299da.png)


## 特に見て欲しいところ
変更点の中で、特に確認が必要なものになります。

* テストのスクリーンショットからメールアドレスを取得できていることを確認
* 例外処理に不備がないか